### PR TITLE
Fixed some ScaledSpace issue

### DIFF
--- a/Source/Planet_GUI.cs
+++ b/Source/Planet_GUI.cs
@@ -2730,8 +2730,8 @@ namespace PFUtilityAddon
 									//key.SetValue( cbobj, ConfigNode.ParseColor( val ) );
 									//print ( "PQS not compatible at this point." );
 									//continue;
-										string FixName = node.GetValue( key.Name );
-										FixName.Replace( " (PQS)", "" );
+									string FixName = node.GetValue( key.Name );
+									FixName = FixName.Replace(" (PQS)", "");
 									key.SetValue( obj, Utils.FindPQS( FixName ) );
 								}
 								

--- a/Source/Planet_GUI.cs
+++ b/Source/Planet_GUI.cs
@@ -533,8 +533,11 @@ namespace PFUtilityAddon
 				GameObject scaledSpace = Utils.FindScaled( TemplateName );
 				
 				PQS pqsGrabtex = localSpace.GetComponentInChildren<PQS>();
-				textures = pqsGrabtex.CreateMaps( 2048, 2000, pqsGrabtex.mapOcean, pqsGrabtex.mapOceanHeight, pqsGrabtex.mapOceanColor );
-				
+				textures = pqsGrabtex.CreateMaps( 2048, pqsGrabtex.mapMaxHeight, pqsGrabtex.mapOcean, pqsGrabtex.mapOceanHeight, pqsGrabtex.mapOceanColor );
+
+				Texture2D Normal = Utils.BumpToNormalMap(textures[1], 9);
+				textures[1] = Normal;
+
 				//Save textures to file.
 				if( ShouldExportScaledMap )
 				{
@@ -545,6 +548,7 @@ namespace PFUtilityAddon
 				
 				MeshRenderer planettextures = scaledSpace.GetComponentInChildren<MeshRenderer>();
 				planettextures.material.SetTexture("_MainTex",PlanetColours);
+				planettextures.material.SetTexture("_BumpMap", Normal);
 				
 				RegenerateModel( pqsGrabtex, scaledSpace.GetComponentInChildren<MeshFilter>() );
 			}if( GUI.Button( new Rect( 220, 240, 20, 20 ), "?" ) ){(NewWindows[ "HelpWindow" ] as HelpWindow).CustomToggle( "ScaledSpaceUpdate" ); }

--- a/Source/Planet_GUI.cs
+++ b/Source/Planet_GUI.cs
@@ -2800,7 +2800,9 @@ namespace PFUtilityAddon
 					//Utils.FindLocal( PlanetName ).GetComponentInChildren<PQS>().RebuildSphere();
 				}
 				print("PlanetUI: Loaded PQS of " +PlanetName+ "\n" );
-					
+
+				// Initial ScaledSpace generation would not work properly without this.
+				Utils.FindLocal(PlanetName).GetComponentInChildren<PQS>().RebuildSphere();
 					
 					//Regen ScaledSpace:
 					string PlanetScaledSpaceTex = "GameData/KittopiaSpace/Textures/ScaledSpace/" + PlanetName + "/colourMap.png";

--- a/Source/Utils.cs
+++ b/Source/Utils.cs
@@ -260,6 +260,28 @@ namespace PFUtilityAddon
 			tempColourString = tempColourString.Replace( ")" , "" );
 			return ConfigNode.ParseColor(tempColourString);
 		}
+
+		// Credit goes to Kragrathea.
+		public static Texture2D BumpToNormalMap(Texture2D source, float strength)
+		{
+			strength = Mathf.Clamp(strength, 0.0F, 10.0F);
+			var result = new Texture2D(source.width, source.height, TextureFormat.ARGB32, true);
+			for (int by = 0; by < result.height; by++)
+			{
+				for (var bx = 0; bx < result.width; bx++)
+				{
+					var xLeft = source.GetPixel(bx - 1, by).grayscale * strength;
+					var xRight = source.GetPixel(bx + 1, by).grayscale * strength;
+					var yUp = source.GetPixel(bx, by - 1).grayscale * strength;
+					var yDown = source.GetPixel(bx, by + 1).grayscale * strength;
+					var xDelta = ((xLeft - xRight) + 1) * 0.5f;
+					var yDelta = ((yUp - yDown) + 1) * 0.5f;
+					result.SetPixel(bx, by, new Color(xDelta, yDelta, 1.0f, xDelta));
+				}
+			}
+			result.Apply();
+			return result;
+		}
 		
 	}
 }

--- a/Source/Utils.cs
+++ b/Source/Utils.cs
@@ -231,6 +231,8 @@ namespace PFUtilityAddon
 		
 		public static void ExportPlanetMaps( string TemplateName, Texture2D[] texture )
 		{
+			Directory.CreateDirectory("GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName);
+
 			byte[] ExportColourMap = texture[0].EncodeToPNG();
 			File.WriteAllBytes("GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/colourMap.png", ExportColourMap);
 

--- a/Source/Utils.cs
+++ b/Source/Utils.cs
@@ -232,27 +232,10 @@ namespace PFUtilityAddon
 		public static void ExportPlanetMaps( string TemplateName, Texture2D[] texture )
 		{
 			byte[] ExportColourMap = texture[0].EncodeToPNG();
-			if( File.Exists( "GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/colourMap.png" ) )
-			{
-    			File.WriteAllBytes("GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/colourMap.png",  ExportColourMap);
-			}
-			else
-			{
-				File.Create( "GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/colourMap.png" );
-				File.WriteAllBytes("GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/colourMap.png",  ExportColourMap);
-			}
-			
+			File.WriteAllBytes("GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/colourMap.png", ExportColourMap);
+
 			ExportColourMap = texture[1].EncodeToPNG();
-			
-			if( File.Exists( "GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/bumpMap.png" ) )
-			{
-				File.WriteAllBytes("GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/bumpMap.png",  ExportColourMap);
-			}
-			else
-			{
-				File.Create( "GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/bumpMap.png" );
-				File.WriteAllBytes("GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/bumpMap.png",  ExportColourMap);
-			}
+			File.WriteAllBytes("GameData/KittopiaSpace/Textures/ScaledSpace/" + TemplateName + "/bumpMap.png", ExportColourMap);
 		}
 		
 		public static void CreateTextFile( string dir, string io )


### PR DESCRIPTION
Hello,

I've been working to fix some issues regarding ScaledSpace generation (and saving/loading). I noticed that you had not used PFCE's BumpToNormalMap function when saving the normal maps.

I tried to (re)add them, and I think the generated bumps worked quite well. But I'm still not quite sure. Was there any problem that you had experienced, so you decided to drop it altogether?